### PR TITLE
fix load of settings

### DIFF
--- a/chrome/content/settings.js
+++ b/chrome/content/settings.js
@@ -355,24 +355,30 @@ SmartTemplate4.Settings = {
 					settings = SmartTemplate4.Settings,
 					getElement = window.document.getElementById.bind(window.document);
     
-    let isAdvancedPanelOpen = prefs.getMyBoolPref('expandSettings'),
+		let isAdvancedPanelOpen = prefs.getMyBoolPref('expandSettings'),
         composeType = null;
 					
 		util.logDebugOptional("functions", "onLoad() …");
+
+		// preferencesBindings waits for all its actions on DOMContentLoaded, 
+		// not only for the init, but also for the load of values.
+		// We need to wait with init until AFTER onDOMContentLoaded,
+		// because we need to manipulate the DOM
+		// When we are ready, we need to retrigger onDOMContentLoaded
+		Services.scriptloader.loadSubScript("chrome://global/content/preferencesBindings.js", window, "UTF-8");
+
 		// Check and set common preference
 		this.setPref1st("extensions.smartTemplate4.");
 		this.disableWithCheckbox();
-
-   // Services.scriptloader.loadSubScript("chrome://global/content/preferencesBindings.js", window, "UTF-8");
     
 		// Set account popup, duplicate DeckB to make account isntances
 		let CurId = this.fillIdentityListPopup();
+		this.loadPreferences(); // initialise instantApply attributes for all nodes (including cloned ones)
+		// DOM is manipulated now, trigger preferencesBindings.js
+		let fakeOnDOMContentLoaded = new Event('DOMContentLoaded');
+		window.dispatchEvent(fakeOnDOMContentLoaded);
     
-    this.loadPreferences(); // initialise instantApply attributes for all nodes (including cloned ones)
-    
-    // Preferences.onDOMContentLoaded(); // calling it manually - it is too late for the COMContentLoaded event
-    
-    // let's take this one out, to see...
+		// let's take this one out, to see...
 		// this.cleanupUnusedPrefs();
 
 		let args = window.arguments,

--- a/chrome/content/settings.xhtml
+++ b/chrome/content/settings.xhtml
@@ -931,6 +931,4 @@
 <script type = "application/javascript" src = "chrome://smarttemplate4/content/smartTemplate-help.js"/>
 <script type = "application/javascript" src = "chrome://smarttemplate4/content/smartTemplate-fileTemplates.js"/>
 
-<script type="application/javascript" src="chrome://global/content/preferencesBindings.js" />
-
 </dialog>


### PR DESCRIPTION
1. Postpone auto actions of preferencesBindings.js by loading it in our own onLoad function, which is after the DOMContentLoaded event has fired, so preferencesBindings.js does not do anything
2. Do all the DOM manipulation
3. Retrigger a DOMContentLoaded event so  preferencesBindings.js can do its job

Make sure to not have any event listeners for DOMContentLoaded in your settings window, as that will now fire twice.