### PR TITLE
Esr78 add conditional text depending on forward mode

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+smartTemplateRev=$( cat revision.txt | xargs )
+oldRev=$smartTemplateRev
+smartTemplateRev=$((smartTemplateRev+1))
+
+sed -i "s/pre$oldRev/pre$smartTemplateRev/g" manifest.json
+
+7z a -xr!.svn smartTemplateWeb.zip manifest.json _locales chrome locale popup st-background.js license.txt icon.png release-notes.html
+
+echo $smartTemplateRev > revision.txt
+mv smartTemplate-*.xpi "../../../Test Versions/3.1/"
+mv smartTemplateWeb.zip smartTemplate-fx-3.1pre$smartTemplateRev.xpi

--- a/chrome/content/smartTemplate-util.js
+++ b/chrome/content/smartTemplate-util.js
@@ -177,6 +177,11 @@ SmartTemplate4.Util = {
 		return st4composeType;
 
 	} ,
+
+	isComposeTypeIsForwardInline: function() {
+		const Ci = Components.interfaces;
+		return gMsgCompose.type === Ci.nsIMsgCompType.ForwardInline;		
+	},
 	
 	getBundleString: function(id, defaultText) {
     const Ci = Components.interfaces;


### PR DESCRIPTION
Hello Axel!

I've been using your add-on for a long time. Thank you for your work!

But I was always missing one function: inserting different text in ForwardAsAttachment and ForwardInline modes.
So, there is my solution: I've added a variable-function customTextDependingOnForwardMode, its prototype:
`
%customTextDependingOnForwardMode("forwardInlineModeText", "forwardAsAttachmentModeText")%`

This function allows me to do the following:

**Quote Header:**

```
Hello.

%customTextDependingOnForwardMode("", "The attachment is the forwarded message.")%
```


**Template:**

```
%customTextDependingOnForwardMode("------------------------------------------", "")%
-- 
Best regards,
 Artem Semenov               mailto:artem.semenov@jarillolabs.com
```

And as a result:

**(ForwardAsAttachment mode)**

```
Hello.

The attachment is the forwarded message.

-- 
Best regards,
 Artem Semenov               mailto:artem.semenov@jarillolabs.com
```


**(ForwardInline mode)**

```
Hello.



-------- Forwarded Message --------
Date: 	Sat, 28 Nov 2020 20:00:39 +0300
From: 	test <test@jarillolabs.com>


Some text.


------------------------------------------
-- 
Best regards,
 Artem Semenov               mailto:artem.semenov@jarillolabs.com
```


In addition, I've added a script to build your add-on in the bash shell.

I've tested the changes I made in Thunderbird 78.5.0

Best regards,
 Artem Semenov